### PR TITLE
WIP: Upsert rows with key columns

### DIFF
--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -880,48 +880,59 @@ class Table(CodaObject):
             for i in r["items"]
         ]
 
-    def upsert_row(self, cells: List[Cell]) -> Dict:
+    def upsert_row(self, cells: List[Cell], key_columns: List[Column] = None) -> Dict:
         """
         Upserts a row using `Cell` objects in list.
 
         :param cells: list of `Cell` objects.
-        """
-        prepared_cells = []
-        for cell in cells:
-            if isinstance(cell.column, str):
-                prepared_cells.append((cell.column, cell.value))
-            elif isinstance(cell.column, Column):
-                prepared_cells.append((cell.column.id, cell.value))
-            else:
-                raise err.InvalidCell(f"{cell} is invalid")
-        data = {
-            "rows": [
-                {
-                    "cells": [
-                        {"column": cell[0], "value": cell[1]} for cell in prepared_cells
-                    ]
-                }
-            ]
-        }
-        return self.document.coda.upsert_row(self.document.id, self.id, data)
 
-    def upsert_rows(self, list_cells: List[List[Cell]]) -> Dict:
+        :param key_columns: list of `Column` objects, column IDs, URLs, or names
+        specifying columns to be used as upsert keys.
         """
-        Works similar to Table.upsert_row() but uses 1 POST request for multiple rows. Input is a list of lists of Cells.
+
+        return self.upsert_rows([cells], key_columns)
+
+    def upsert_rows(
+        self, rows: List[List[Cell]], key_columns: List[Column] = None
+    ) -> Dict:
+        """
+        Works similar to Table.upsert_row() but uses 1 POST request for multiple rows.
+        Input is a list of lists of Cells.
 
         :param list_cells: list of lists of `Cell` objects, one list for each row.
+
+        :param key_columns: list of `Column` objects, column IDs, URLs, or names
+        specifying columns to be used as upsert keys.
         """
         data = {
             "rows": [
                 {
                     "cells": [
-                        {"column": cell.column.id, "value": cell.value}
-                        for cell in cells
+                        {"column": cell.column.id, "value": cell.value} for cell in row
                     ]
                 }
-                for cells in list_cells
+                for row in rows
             ]
         }
+
+        if key_columns:
+            if not isinstance(key_columns, list):
+                raise err.ColumnNotFound(
+                    f"key_columns parameter '{key_columns}' is not a list."
+                )
+
+            data["keyColumns"] = []
+
+            for key_column in key_columns:
+                if isinstance(key_column, Column):
+                    data["keyColumns"].append(key_column.id)
+                elif isinstance(key_column, str):
+                    data["keyColumns"].append(key_column)
+                else:
+                    raise err.ColumnNotFound(
+                        f"Invalid parameter: '{key_column}' in key_columns."
+                    )
+
         return self.document.coda.upsert_row(self.document.id, self.id, data)
 
     def update_row(self, row: Union[str, Row], cells: List[Cell]) -> Dict:

--- a/tests/test_Table.py
+++ b/tests/test_Table.py
@@ -51,3 +51,42 @@ class TestTable:
         assert isinstance(row, Row)
         assert row[cell_1.column.id].value == cell_1.value
         assert row[cell_2.column.id].value == cell_2.value
+
+    def test_upsert_rows(self, main_table):
+        columns = main_table.columns()
+
+        rows = []
+        for row in range(1, 11):
+            rows.append(
+                [Cell(column, f"value-{str(row)}-{column.name}") for column in columns]
+            )
+
+        result = main_table.upsert_rows(rows)
+
+        assert result["status"] == 202
+
+        key_column = columns[0]
+
+        cell_to_update_1 = Cell(key_column, f"value-5-{columns[0].name}")
+        cell_to_update_2 = Cell(columns[1], "updated_value")
+
+        row_to_update = [cell_to_update_1, cell_to_update_2]
+
+        result = main_table.upsert_rows([row_to_update], key_columns=[key_column])
+
+        assert result["status"] == 202
+
+        updated_rows = None
+        while not updated_rows:
+            updated_rows = main_table.find_row_by_column_id_and_value(
+                cell_to_update_1.column.id, cell_to_update_1.value
+            )
+            time.sleep(1)
+
+        assert len(updated_rows) == 1
+
+        updated_row = updated_rows[0]
+        assert (
+            updated_row.get_cell_by_column_id(columns[1].id).value
+            == cell_to_update_2.value
+        )


### PR DESCRIPTION
Hello there!

Thank you for your work.
I'm scratching my own itch with this PR to upsert tables with the keyColumns parameter.

- [x] Support passing `key columns` to the upsert table row API call.
- [x] Remove duplicate code between `Table.upsert_rows()` and `Table.upsert_row()`
- [x] Add a basic test for `upsert_rows`
- [ ] Update documentation and docstrings properly

Please do let me know how to improve or adapt this PR, I'm quite new to the GitHub game.