### PR TITLE
Add the option to send a json payload with a delete call.

### DIFF
--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -158,14 +158,19 @@ class Coda:
 
     # noinspection PyTypeChecker
     @handle_response
-    def delete(self, endpoint: str) -> Dict:
+    def delete(self, endpoint: str, data: Dict = None) -> Dict:
         """
         Makes a DELETE request to the API endpoint.
 
         :param endpoint: API endpoint to request
 
+        :param data: data dict to be sent as body json
+
         :return:
         """
+        if data:
+            return requests.delete(self.href + endpoint, json=data, headers=self.authorization)
+        
         return requests.delete(self.href + endpoint, headers=self.authorization)
 
     def list_docs(

--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -168,9 +168,11 @@ class Coda:
 
         :return:
         """
-        if data:
-            return requests.delete(self.href + endpoint, json=data, headers=self.authorization)
-        
+        if data is not None:
+            return requests.delete(
+                self.href + endpoint, json=data, headers=self.authorization
+            )
+
         return requests.delete(self.href + endpoint, headers=self.authorization)
 
     def list_docs(


### PR DESCRIPTION
Necessary for supporting API calls such as: https://coda.io/developers/apis/v1#operation/deleteRows
