### PR TITLE
added default_value attribute to Column class constructor

### DIFF
--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -1068,6 +1068,7 @@ class Column(CodaObject):
     display: bool = attr.ib(default=None, repr=False)
     calculated: bool = attr.ib(default=False)
     formula: str = attr.ib(default=None, repr=False)
+    default_value: str = attr.ib(default=None, repr=False)
 
 
 @attr.s(auto_attribs=True, hash=True)


### PR DESCRIPTION
The library is throwing this error

`TypeError: __init__() got an unexpected keyword argument 'default_value'`

This pr includes the fix for the Column class constructor