### PR TITLE
API params in list_rows

### DIFF
--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -446,6 +446,7 @@ class Coda:
         table_id_or_name: str,
         query: str = None,
         use_column_names: bool = False,
+        visible_only: bool = False,
         limit: int = None,
         offset: int = None,
     ) -> Dict:
@@ -470,15 +471,16 @@ class Coda:
             This is generally discouraged as it is fragile.
             If columns are renamed, code using original names may throw errors.
 
+        :param visible_only: If true, returns only visible rows and columns for the table.
         :param limit: Maximum number of results to return in this query.
 
         :param offset: An opaque token used to fetch the next page of results.
         """
-        data = {"useColumnNames": use_column_names}
+        data = {"useColumnNames": use_column_names, "visibleOnly": visible_only}
         if query:
             data["query"] = query
 
-        return self.get(
+        return self.getk
             f"/docs/{doc_id}/tables/{table_id_or_name}/rows",
             data=data,
             limit=limit,
@@ -860,7 +862,7 @@ class Table(CodaObject):
             ]
         return self.columns_storage
 
-    def rows(self, offset: int = None, limit: int = None) -> List[Row]:
+    def rows(self, offset: int = None, limit: int = None, **kwargs) -> List[Row]:
         """
         Returns list of Table rows.
 
@@ -868,12 +870,14 @@ class Table(CodaObject):
 
         :param offset: An opaque token used to fetch the next page of results.
 
+        :param kwargs: Pass through API parameters to the list_rows method.
+
         :return:
         """
         return [
             Row.from_json({"table": self, **i}, document=self.document)
             for i in self.document.coda.list_rows(
-                self.document.id, self.id, offset=offset, limit=limit
+                self.document.id, self.id, offset=offset, limit=limit, **kwargs
             )["items"]
         ]
 


### PR DESCRIPTION
Hey, I love your library! I'd love to have more granular control of how we fetch rows. 

This PR starts small, but I'd add to it if you approve of the pattern. Current changes:

- add `visible_only` to `list_rows` method
- Allow `Table.rows` method to pass API params to `list_rows` in the form of `**kwargs`

If you're not into the kwargs approach, I could just add all the existing API parameters to the `list_rows` function and just write my own wrapper, but I feel like other users might like that extra control.