### PR TITLE
Handle filter and parentTable in table json

### DIFF
--- a/codaio/coda.py
+++ b/codaio/coda.py
@@ -819,6 +819,8 @@ class Table(CodaObject):
         repr=False, converter=lambda x: parse(x) if x else None, default=None
     )
     columns_storage: List[Column] = attr.ib(default=[], repr=False)
+    filter: Dict = attr.ib(default=None, repr=False)
+    parent_table: Table = attr.ib(default=None, repr=False)
 
     def __getitem__(self, item):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codaio"
-version = "0.6.9"
+version = "0.6.10"
 description = "Python wrapper for Coda.io API"
 authors = ["MB <mb@blaster.ai>"]
 license = "MIT"

--- a/tests/data/get_table.json
+++ b/tests/data/get_table.json
@@ -21,5 +21,27 @@
   "createdAt": "2020-01-01T00:00:00.000Z",
   "updatedAt": "2020-01-01T00:00:00.000Z",
   "sorts": [],
-  "layout": "default"
+  "layout": "default",
+  "filter": {
+    "valid": true,
+    "isVolatile": false,
+    "hasUserFormula": false,
+    "hasTodayFormula": false,
+    "hasNowFormula": false
+  },
+  "parentTable": {
+    "id": "grid-pqRst-U",
+    "type": "table",
+    "tableType": "table",
+    "href": "https://coda.io/apis/v1/docs/AbCDeFGH/tables/grid-pqRst-U",
+    "browserLink": "https://coda.io/d/_dAbCDeFGH/#Teams-and-Tasks_tpqRst-U",
+    "name": "Tasks",
+    "parent": {
+      "id": "canvas-IjkLmnO",
+      "type": "page",
+      "href": "https://coda.io/apis/v1/docs/AbCDeFGH/pages/canvas-IjkLmnO",
+      "browserLink": "https://coda.io/d/_dAbCDeFGH/Launch-Status_sumnO",
+      "name": "Launch Status"
+    }
+  }
 }


### PR DESCRIPTION
I was running into an error when getting tables with filters on them. This allows the tables to load. When I checked the API docs it looks like the parentTable field is another one that can exist in the json, so put that in for good measure while I was in there.